### PR TITLE
Use kwarg `workers` not `n_jobs` for `cKDTree`

### DIFF
--- a/mnnpy/utils.py
+++ b/mnnpy/utils.py
@@ -89,8 +89,8 @@ def transform_input_data(datas, cos_norm_in, cos_norm_out, var_index, var_subset
 # forceobj=True due to: Untyped global name 'cKDTree': cannot determine Numba type of <class 'type'>
 @jit((float32[:, :], float32[:, :], int8, int8, int8), forceobj=True)
 def find_mutual_nn(data1, data2, k1, k2, n_jobs):
-    k_index_1 = cKDTree(data1).query(x=data2, k=k1, n_jobs=n_jobs)[1]
-    k_index_2 = cKDTree(data2).query(x=data1, k=k2, n_jobs=n_jobs)[1]
+    k_index_1 = cKDTree(data1).query(x=data2, k=k1, workers=n_jobs)[1]
+    k_index_2 = cKDTree(data2).query(x=data1, k=k2, workers=n_jobs)[1]
     mutual_1 = []
     mutual_2 = []
     for index_2 in range(data2.shape[0]):


### PR DESCRIPTION
`scipy.spatial.cKDTree` replaced `n_jobs` with `workers` in 1.6.0 and [removed `n_jobs` in 1.9.0](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.cKDTree.query.html). This currently causes an error in [openproblems](https://github.com/openproblems-bio/openproblems/runs/7655839315?check_suite_focus=true#step:12:991)